### PR TITLE
Add API to Give Weight Management Tips

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/WeightManagementTipController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/WeightManagementTipController.java
@@ -1,0 +1,25 @@
+package tech.bread.solt.doctornyangserver.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.bread.solt.doctornyangserver.model.dto.request.ShowWeightManagementRequest;
+import tech.bread.solt.doctornyangserver.service.WeightManagementTipService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/weight-management-tip")
+public class WeightManagementTipController {
+    final WeightManagementTipService weightManagementTipService;
+
+    public WeightManagementTipController(WeightManagementTipService weightManagementTipService) {
+        this.weightManagementTipService = weightManagementTipService;
+    }
+
+    @PostMapping("/show")
+    public List<String> showWeightManagementTips(@RequestBody ShowWeightManagementRequest request) {
+        return weightManagementTipService.showWeightManageTip(request);
+    }
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/ShowWeightManagementRequest.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/ShowWeightManagementRequest.java
@@ -1,0 +1,12 @@
+package tech.bread.solt.doctornyangserver.model.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShowWeightManagementRequest {
+    private int userUid;
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/repository/WeightManagementTipRepo.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/repository/WeightManagementTipRepo.java
@@ -1,0 +1,12 @@
+package tech.bread.solt.doctornyangserver.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tech.bread.solt.doctornyangserver.model.entity.BMIRange;
+import tech.bread.solt.doctornyangserver.model.entity.WeightManagementTip;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WeightManagementTipRepo extends JpaRepository<WeightManagementTip, Integer> {
+    List<WeightManagementTip> findByBmiRangeId(BMIRange bmiRangeId);
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/WeightManagementTipService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/WeightManagementTipService.java
@@ -1,0 +1,10 @@
+package tech.bread.solt.doctornyangserver.service;
+
+import tech.bread.solt.doctornyangserver.model.dto.request.ShowWeightManagementRequest;
+import tech.bread.solt.doctornyangserver.model.entity.User;
+
+import java.util.List;
+
+public interface WeightManagementTipService {
+    List<String> showWeightManageTip(ShowWeightManagementRequest request);
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/WeightManagementTipServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/WeightManagementTipServiceImpl.java
@@ -1,0 +1,39 @@
+package tech.bread.solt.doctornyangserver.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import tech.bread.solt.doctornyangserver.model.dto.request.ShowWeightManagementRequest;
+import tech.bread.solt.doctornyangserver.model.entity.User;
+import tech.bread.solt.doctornyangserver.model.entity.WeightManagementTip;
+import tech.bread.solt.doctornyangserver.repository.UserRepo;
+import tech.bread.solt.doctornyangserver.repository.WeightManagementTipRepo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WeightManagementTipServiceImpl implements WeightManagementTipService {
+    private final UserRepo userRepo;
+    private final WeightManagementTipRepo weightManagementTipRepo;
+    @Override
+    public List<String> showWeightManageTip(ShowWeightManagementRequest request) {
+        Optional<User> optionalUser = userRepo.findById(request.getUserUid());
+        List<WeightManagementTip> weightManagementTips;
+        List<String> res = new ArrayList<>();
+
+        if (optionalUser.isPresent()) {
+            weightManagementTips = weightManagementTipRepo.findByBmiRangeId(optionalUser.get().getBmiRangeId());
+            if (weightManagementTips.isEmpty()){
+                res.add("유저의 BMI 값이 설정되어 있지 않습니다.");
+                return res;
+            }
+            for (WeightManagementTip wmt : weightManagementTips)
+                res.add(wmt.getTip());
+            return res;
+        }
+        res.add("찾고자 하는 유저가 존재하지 않습니다.");
+        return res;
+    }
+}


### PR DESCRIPTION
## 개요
- 유저의 BMI 값에 따른 체중 관리 팁을 주는 API를 작성했습니다.

## 작업 내용
- WeightManagementTip에 대한 Controller, Repo, Service, ServiceImpl을 추가했습니다.
- 유저의 BmiRangeId를 참고하여 WeightManagementTip 테이블에서 그에 맞는 조언들을 유저에게 보여줍니다.

## 이미지
1. 성공
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/6a31a939-5725-469d-b820-3ade06c3ea2f)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/eb78f76b-7f2b-4339-a510-967f8fe01922)
2. 실패: 유저가 BMI Range를 설정하지 않은 경우
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/aa5c9c22-d075-45d5-88e7-870a936b8b79)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/fb327159-99fd-491f-80a3-18fbb962ff9e)
3. 실패: 유저가 존재하지 않는 경우
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/6131d4d6-6a33-4dcf-aa6a-9c14354ae9af)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/b71ac4a2-79b9-4455-8877-6d2897639097)