### PR TITLE
Update API To Show User's Information

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/UserController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/UserController.java
@@ -1,12 +1,10 @@
 package tech.bread.solt.doctornyangserver.controller;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import tech.bread.solt.doctornyangserver.model.dto.request.EnterBodyInformationRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.LoginRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.RegisterRequest;
+import tech.bread.solt.doctornyangserver.model.dto.response.UserInfoResponse;
 import tech.bread.solt.doctornyangserver.service.UserService;
 
 @RestController
@@ -30,5 +28,10 @@ public class UserController {
     @PostMapping("/enter-body-information")
     public int enterBodyInformation(@RequestBody EnterBodyInformationRequest request){
         return userService.enterBodyInformation(request);
+    }
+
+    @GetMapping("/show-info/{uid}")
+    public UserInfoResponse showUserInformation(@PathVariable("uid") int uid){
+        return userService.showUser(uid);
     }
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/UserInfoResponse.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/UserInfoResponse.java
@@ -1,0 +1,22 @@
+package tech.bread.solt.doctornyangserver.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import tech.bread.solt.doctornyangserver.model.entity.User;
+
+import java.time.LocalDate;
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserInfoResponse {
+    String id;
+    String nickName;
+    LocalDate birth;
+    double height;
+    double weight;
+    double bmr;
+    String bmiRangeName;
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/repository/BMIRangeRepo.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/repository/BMIRangeRepo.java
@@ -5,4 +5,5 @@ import tech.bread.solt.doctornyangserver.model.entity.BMIRange;
 
 public interface BMIRangeRepo extends JpaRepository<BMIRange, Integer> {
     BMIRange findOneById(int bmiId);
+    BMIRange findById(int bmiId);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/UserService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/UserService.java
@@ -3,9 +3,12 @@ package tech.bread.solt.doctornyangserver.service;
 import tech.bread.solt.doctornyangserver.model.dto.request.EnterBodyInformationRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.LoginRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.RegisterRequest;
+import tech.bread.solt.doctornyangserver.model.dto.response.UserInfoResponse;
 
 public interface UserService {
     int register(RegisterRequest request);
     int login(LoginRequest request);
     int enterBodyInformation(EnterBodyInformationRequest request);
+
+    UserInfoResponse showUser(int uid);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/UserServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/UserServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import tech.bread.solt.doctornyangserver.model.dto.request.EnterBodyInformationRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.LoginRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.RegisterRequest;
+import tech.bread.solt.doctornyangserver.model.dto.response.UserInfoResponse;
 import tech.bread.solt.doctornyangserver.model.entity.BMIRange;
 import tech.bread.solt.doctornyangserver.model.entity.Schedule;
 import tech.bread.solt.doctornyangserver.model.entity.User;
@@ -137,6 +138,27 @@ public class UserServiceImpl implements UserService{
 
             return 200;
         }
+    }
+
+    @Override
+    public UserInfoResponse showUser(int uid) {
+        Optional<User> u = userRepo.findById(uid);
+        UserInfoResponse userInfoResponse;
+        if(u.isPresent()) {
+            User user = u.get();
+            Optional<BMIRange> bmi = bmiRangeRepo.findById(user.getBmiRangeId().getId());
+            userInfoResponse = UserInfoResponse.builder()
+                    .id(user.getId())
+                    .nickName(user.getNickname())
+                    .birth(user.getBirthDate())
+                    .bmr(user.getBmr())
+                    .weight(user.getWeight())
+                    .height(user.getHeight())
+                    .bmiRangeName(bmi.get().getName()).build();
+
+            return userInfoResponse;
+        }
+        return null;
     }
 
     private boolean isUnique(String id){


### PR DESCRIPTION
## 개요
사용자가 입력한 개인정보를 사용자가 열람할 수 있는 API를 작성했습니다.

## 작업 내용
GET 방식을 이용해 uid를 입력하면 사용자의 개인정보를 열람할 수 있습니다. 비밀번호와 salt 값을 제외한 값들을 열람할 수 있습니다.

## 이미지
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/e13b0788-757f-447a-adb2-1d7746e5dd2b)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/167ed36d-ae30-4ddb-b4c8-5fe6a1b0e203)