### PR TITLE
Add API To Show User's Dosage Information

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/DosageController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/DosageController.java
@@ -1,13 +1,13 @@
 package tech.bread.solt.doctornyangserver.controller;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import tech.bread.solt.doctornyangserver.model.dto.request.DoneDosageRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.DosageRegisterRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.SetPrivateDosageRequest;
+import tech.bread.solt.doctornyangserver.model.entity.Dosage;
 import tech.bread.solt.doctornyangserver.service.DosageService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/dosage")
@@ -31,5 +31,10 @@ public class DosageController {
     @PostMapping("/private-set")
     public int setPrivateDosage(@RequestBody SetPrivateDosageRequest request){
         return dosageService.registerPrivateDosage(request);
+    }
+
+    @GetMapping("/show/{uid}")
+    public List<Dosage> getMedicineDosage(@PathVariable("uid") int uid){
+        return dosageService.getMedicineDosage(uid);
     }
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/repository/DosageRepo.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/repository/DosageRepo.java
@@ -7,8 +7,11 @@ import tech.bread.solt.doctornyangserver.model.entity.User;
 import tech.bread.solt.doctornyangserver.util.Times;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface DosageRepo extends JpaRepository<Dosage, Integer>{
     Optional<Dosage> findByUserUidAndMedicineIdAndTimesAndDate(User uid, Medicine medicineId, Times times, LocalDate date);
+
+    List<Dosage> findByUserUid(User uid);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/DosageService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/DosageService.java
@@ -3,9 +3,13 @@ package tech.bread.solt.doctornyangserver.service;
 import tech.bread.solt.doctornyangserver.model.dto.request.DoneDosageRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.DosageRegisterRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.SetPrivateDosageRequest;
+import tech.bread.solt.doctornyangserver.model.entity.Dosage;
+
+import java.util.List;
 
 public interface DosageService {
     int registerDosage(DosageRegisterRequest request);
     Boolean toggleDosage(DoneDosageRequest request);
     int registerPrivateDosage(SetPrivateDosageRequest request);
+    List<Dosage> getMedicineDosage(int uid);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/DosageServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/DosageServiceImpl.java
@@ -13,7 +13,6 @@ import tech.bread.solt.doctornyangserver.repository.MedicineRepo;
 import tech.bread.solt.doctornyangserver.repository.UserRepo;
 import tech.bread.solt.doctornyangserver.util.Times;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -137,5 +136,24 @@ public class DosageServiceImpl implements DosageService {
         }
         System.out.println("등록 실패: 약 정보가 없음");
         return 500;
+    }
+
+    @Override
+    public List<Dosage> getMedicineDosage(int uid) {
+        Optional<User> u = userRepo.findById(uid);
+        if (u.isPresent()) {
+            List<Dosage> d = dosageRepo.findByUserUid(u.get());
+
+            if (d.isEmpty()) {
+                System.out.println("등록된 의약품 복용 일정이 없습니다.");
+                return null;
+            }
+            else{
+                System.out.println("복용 일정 가져오기 성공");
+                return d;
+            }
+        }
+        System.out.println("찾고자 하는 User 없음");
+        return null;
     }
 }


### PR DESCRIPTION
## 개요
사용자가 복용 중인 의약품에 대한 정보를 가져오는 API를 추가했습니다.

## 작업내용
사용자가 복용 중인 의약품에 대한 정보를 전부 가져옵니다. 서비스 로그인이 이루어지면 반환 되는 사용자의 아이디 값을 바탕으로 값을 불러옵니다.

## 이미지
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/f0f6c194-6d48-44aa-b16b-ad53fff580a8)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/9837c176-24e0-44df-a0d6-b003d71ab992)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/b54e5a88-f355-4952-a382-d5e5020d60bd)