### PR TITLE
Update API To Register Dosage Schedule

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/service/DosageServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/DosageServiceImpl.java
@@ -138,7 +138,7 @@ public class DosageServiceImpl implements DosageService {
 
             int count = 0;
             for (int i = 0; i < doseDays; i++) {
-                for (int j = 0; j < medicine.getDailyDosage(); j++) {
+                for (int j = 0; j < (medicine.getDailyDosage() / medicine.getOnceDosage()); j++) {
                     count++;
                     dosageRepo.save(Dosage.builder()
                             .date(request.getStartDate().plusDays(i))
@@ -146,7 +146,7 @@ public class DosageServiceImpl implements DosageService {
                             .times(Times.ofOrdinal(ordinals.get(j)))
                             .medicineId(m.get())
                             .medicineTaken(false).build());
-                    if (count >= medicine.getTotalDosage())
+                    if (count >= (medicine.getTotalDosage() / medicine.getOnceDosage()))
                         break;
                 }
             }


### PR DESCRIPTION
## 개요
의약품 복용 일정 등록 중에 날짜가 나누어 떨어지지 않는 경우나, 하루 2회 복용하는 경우에 아침, 점심 약으로 등록 되는 경우가 있었으며, 하루 2회 복용인데도 불구하고 1일 3회 복용으로 저장되는 경우가 있었습니다. 이를 수정하였습니다.

## 작업 내용
- 약을 복용하는 총 일수는 총 복용량 / 일일 복용량으로 구합니다. 이 때 나머지값이 생기는 경우, 결과 값을 1일 더 추가합니다. 이후 총 복용량과 비교하여 값이 남았다면 복용 횟수를 추가하여 총 복용량과 값을 맞춥니다.
- 1일 2회 복용하는 경우, 1회 2정 복용하는 경우에 대한 예외를 switch-case문을 사용해 처리했습니다. 1회 복용량을 우선적으로 고려하고 1일 복용량을 고려합니다. 이에 따라 복용 시간을 조정합니다.

## 이미지
1. 총 복용량 / 1일 복용량이 나누어 떨어지지 않는 경우
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/283a764c-3751-4cdd-b813-1baadde052cd)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/36d5e253-4cbf-4866-af51-cd1421f107d3)
2. 1일 2회 복용하는 경우
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/282c9a12-9ffd-426e-b18a-c966b9bc363e)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/52e9b2ba-13bf-4889-82e8-6d99e9eb8d4b)
3. 1회 2정 복용하는 경우
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/47344bee-e2fc-4606-8f22-514300420d2c)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/29d32b8f-9dec-42a7-a146-78c051196dc0)
