### PR TITLE
Add feeding API, Scheduler

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/NabiController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/NabiController.java
@@ -34,4 +34,8 @@ public class NabiController {
         return nabiService.createChat(request);
     }
 
+    @GetMapping("/feed/{uid}")
+    public int feed(@PathVariable("uid") int uid) {
+        return nabiService.feed(uid);
+    }
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/entity/User.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/entity/User.java
@@ -49,4 +49,10 @@ public class User {
 
     @Column(name = "done_tutorial")
     Boolean doneTutorial;
+
+    @Column(name= "fed")
+    Boolean fed;
+
+    @Column(name="likeability")
+    Integer likeability;
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/repository/UserRepo.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/repository/UserRepo.java
@@ -10,4 +10,5 @@ public interface UserRepo extends JpaRepository<User, Integer> {
     Optional<User> findById(String id);
 
     User findOneByUid(int uid);
+    List<User> findByFedIsTrue();
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/NabiService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/NabiService.java
@@ -13,4 +13,6 @@ public interface NabiService {
     List<GetChatResponse> getChats(int uid);
 
     List<GetChatResponse> getChats(int uid, int page);
+
+    int feed(int uid);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/NabiServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/NabiServiceImpl.java
@@ -27,7 +27,9 @@ import java.util.Optional;
 public class NabiServiceImpl implements NabiService {
 
     final private UserRepo userRepo;
-    private final ChatRepo chatRepo;
+    final private ChatRepo chatRepo;
+
+    private int LIKEABILITY_SCORE = 3;
 
     @Override
     public String createChat(CreateChatRequest request) {
@@ -107,5 +109,34 @@ public class NabiServiceImpl implements NabiService {
 
         return result;
     }
+
+    @Override
+    public int feed(int uid) {
+        int result = 400;
+        Optional<User> optionalUser = userRepo.findById(uid);
+
+        if (optionalUser.isEmpty()) {
+            System.out.println("먹이 주기 실패: 유저가 존재하지 않음");
+            return result;
+        }
+        else {
+            User user = optionalUser.get();
+
+            if (user.getFed()) {
+                System.out.println("먹이 주기 실패: 오늘 먹이를 이미 줬습니다.");
+                result = 300;
+            }
+            else {
+                user.setFed(true);
+                user.setLikeability(user.getLikeability() + LIKEABILITY_SCORE);
+                System.out.println("먹이 주기 성공, 현재 호감도: " + user.getLikeability());
+                userRepo.save(user);
+                result = 200;
+            }
+        }
+
+        return result;
+    }
+
 
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/util/Scheduler.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/util/Scheduler.java
@@ -44,6 +44,21 @@ public class Scheduler {
         }
     }
 
+//    @Scheduled(cron = "*/5 * * * * *")
+    @Scheduled(cron = "0 0 6 * * *")
+    public void feedSchedule() {
+        List<User> fedUsers = userRepo.findByFedIsTrue();
+        List<User> users = new ArrayList<>();
+
+        for (User user : fedUsers) {
+            user.setFed(false);
+            users.add(user);
+        }
+
+        userRepo.saveAll(users);
+        System.out.println("먹이 주기 초기화 완료");
+    }
+
 //    @Scheduled(cron = "0 0 8 1 * *")
 //    public void alertMonthlyReport() {
 //        LocalDate today = LocalDate.now();


### PR DESCRIPTION
## 개요
먹이를 주고, 먹이를 준 횟수에 따른 호감도 설정을 위해 작업했습니다.

## 작업 내용
먹이 주기를 위해 데이터베이스에 칼럼 두 개를 추가했습니다.
먹이 주기 API와 하루 한 번 먹이 주기를 위한 스케줄러를 추가했습니다.

### 추가된 사항
데이터베이스에서 유저 테이블에 호감도 칼럼(likeability), 오늘 먹이를 주었는가에 대한 칼럼(fed)을 추가했습니다.
아침 6시마다 먹이 주기를 초기화하는 스케줄러를 추가했습니다.
uid로 먹이 주기를 수행하는 API 를 추가했습니다.
관련 내용 노션에 업데이트 했습니다.

## 이미지
<img width="721" alt="image" src="https://github.com/salt-bread-tech/doctor-nyang-server/assets/83108398/cbc405ec-34fa-4ff8-a5e5-da692282e853">
