### PR TITLE
Add 'Gender' Column In User Table And Update API To Calculate BMR, BMI

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/UserInfoResponse.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/UserInfoResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import tech.bread.solt.doctornyangserver.model.entity.User;
+import tech.bread.solt.doctornyangserver.util.Gender;
 
 import java.time.LocalDate;
 @Data
@@ -15,6 +16,7 @@ public class UserInfoResponse {
     String id;
     String nickName;
     LocalDate birth;
+    String gender;
     double height;
     double weight;
     double bmr;

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/entity/User.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/entity/User.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import tech.bread.solt.doctornyangserver.util.Gender;
 
 import java.time.LocalDate;
 
@@ -33,6 +34,10 @@ public class User {
 
     @Column(name = "birth_date")
     LocalDate birthDate;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "gender")
+    Gender gender;
 
     @Column(name = "height")
     Double height;

--- a/src/main/java/tech/bread/solt/doctornyangserver/util/Gender.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/util/Gender.java
@@ -1,0 +1,5 @@
+package tech.bread.solt.doctornyangserver.util;
+
+public enum Gender {
+    MALE, FEMALE
+}


### PR DESCRIPTION
## 개요
- 사용자 정보를 나타내는 user 테이블에 성별 관련 컬럼이 없어 gender 컬럼을 추가했습니다.
- 사용자 정보를 저장할 때 키와 몸무게의 상/하한값을 설정했습니다.

## 작업내용
- 사용자 정보에 gender 컬럼을 추가함에 따라 회원가입, 사용자 정보 수정 API가 수정되었습니다.
- 사용자가 입력한 값에 따라 BMR, BMI 값을 저장하는 API에 키와 몸무게의 상/하한값을 검토하는 라인을 추가했습니다.
  - 사용자의 키는 65 ~ 251 사이 값이어야 합니다.
  - 사용자의 몸무게는 6 ~ 769 사이 값이어야 합니다.

## 이미지
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/1f030288-f482-407e-aef2-cb06c928a470)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/f4181c12-1f39-4fc7-85ec-699d4030f88a)
- 상/하한값을 잘못 입력하는 경우
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/db4f077e-f450-4844-971a-75b22a4783b5)
- 성별 컬럼을 추가: 회원가입시 저장, 수정 가능
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/46f9bc89-24d3-425c-b30c-78182548deb5)

