### PR TITLE
Add Code To Check Regular Expressions Of User ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,14 @@ dependencies {
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     implementation 'org.jsoup:jsoup:1.15.3'
     implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.1'
+    implementation 'org.jetbrains:annotations:24.0.0'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/entity/User.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/entity/User.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import tech.bread.solt.doctornyangserver.util.Gender;
+import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDate;
 


### PR DESCRIPTION
## 개요
사용자 아이디를 입력받을 때 사용자 아이디에 대한 정규표현식을 추가했습니다.

## 작업내용
1. 사용자 아이디는 영어(대소문자 구분 없음)와 숫자로만 이루어져야 합니다.
2. "@"나 "."이 아이디에 포함된 경우 이메일 형식을 따라야 합니다.
이에 따른 정규표현식을 추가했습니다.

## 이미지
1. 실패하는 경우
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/0b0843bd-e702-464b-9da3-4d30f64d9a32)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/3afe4319-2d07-4f75-aac4-f575d4ca1030)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/19fb0bf2-b6b4-4732-836f-f3eb1891c4de)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/237d62f8-2d28-445b-ace3-ad95e909e163)
2. 성공하는 경우
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/5a609491-45a6-43be-9b24-3cfa4590ee93)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/a5c9ae35-9060-4dc9-9c97-79cd8d5d4a2d)
![image](https://github.com/salt-bread-tech/doctor-nyang-server/assets/94215392/2a6a7a4e-033a-4cf0-9a14-c1a303b320e4)

