### PR TITLE
Add Column 'create_at' And API To Calculate D+Days

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/UserController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/UserController.java
@@ -5,10 +5,13 @@ import org.springframework.web.bind.annotation.*;
 import tech.bread.solt.doctornyangserver.model.dto.request.EnterBodyInformationRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.LoginRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.RegisterRequest;
+import tech.bread.solt.doctornyangserver.model.dto.response.CountingDaysResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.LoginResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.RegisterResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.UserInfoResponse;
 import tech.bread.solt.doctornyangserver.service.UserService;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/user")
@@ -36,5 +39,10 @@ public class UserController {
     @GetMapping("/show-info/{uid}")
     public UserInfoResponse showUserInformation(@PathVariable("uid") int uid) {
         return userService.showUser(uid);
+    }
+
+    @GetMapping("/counting")
+    public CountingDaysResponse test(Principal p) {
+        return userService.countingDays(p.getName());
     }
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/CountingDaysResponse.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/CountingDaysResponse.java
@@ -1,0 +1,14 @@
+package tech.bread.solt.doctornyangserver.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class CountingDaysResponse {
+    int days;
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/entity/User.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/entity/User.java
@@ -60,4 +60,7 @@ public class User {
 
     @Column(name="likeability")
     Integer likeability;
+
+    @Column(name = "create_at")
+    LocalDate createAt;
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/UserService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/UserService.java
@@ -4,13 +4,16 @@ import org.springframework.http.ResponseEntity;
 import tech.bread.solt.doctornyangserver.model.dto.request.EnterBodyInformationRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.LoginRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.RegisterRequest;
+import tech.bread.solt.doctornyangserver.model.dto.response.CountingDaysResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.LoginResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.RegisterResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.UserInfoResponse;
+
 
 public interface UserService {
     ResponseEntity<? super RegisterResponse> register(RegisterRequest request);
     ResponseEntity<? super LoginResponse> login(LoginRequest request);
     int enterBodyInformation(EnterBodyInformationRequest request);
     UserInfoResponse showUser(int uid);
+    CountingDaysResponse countingDays(String userId);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/UserServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/UserServiceImpl.java
@@ -8,10 +8,7 @@ import org.springframework.stereotype.Service;
 import tech.bread.solt.doctornyangserver.model.dto.request.EnterBodyInformationRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.LoginRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.RegisterRequest;
-import tech.bread.solt.doctornyangserver.model.dto.response.LoginResponse;
-import tech.bread.solt.doctornyangserver.model.dto.response.RegisterResponse;
-import tech.bread.solt.doctornyangserver.model.dto.response.ResponseDto;
-import tech.bread.solt.doctornyangserver.model.dto.response.UserInfoResponse;
+import tech.bread.solt.doctornyangserver.model.dto.response.*;
 import tech.bread.solt.doctornyangserver.model.entity.BMIRange;
 import tech.bread.solt.doctornyangserver.model.entity.Schedule;
 import tech.bread.solt.doctornyangserver.model.entity.User;
@@ -20,13 +17,12 @@ import tech.bread.solt.doctornyangserver.repository.ScheduleRepo;
 import tech.bread.solt.doctornyangserver.repository.UserRepo;
 import tech.bread.solt.doctornyangserver.security.JwtProvider;
 import tech.bread.solt.doctornyangserver.util.Gender;
+
+import java.util.*;
 import java.util.regex.Pattern;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +34,17 @@ public class UserServiceImpl implements UserService{
 
     private final JwtProvider jwtProvider;
     private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @Override
+    public CountingDaysResponse countingDays(String userId) {
+        Optional<User> user = userRepo.findById(userId);
+        if (user.isPresent()){
+            User u = user.get();
+            return CountingDaysResponse.builder()
+                    .days((int)ChronoUnit.DAYS.between(u.getCreateAt(), LocalDate.now())).build();
+        }
+        return CountingDaysResponse.builder().build();
+    }
 
     @Override
     public ResponseEntity<? super RegisterResponse> register(RegisterRequest request) {
@@ -88,7 +95,8 @@ public class UserServiceImpl implements UserService{
                             .doneTutorial(false)
                             .fed(false)
                             .likeability(0)
-                            .userRole("ROLE_USER").build());
+                            .userRole("ROLE_USER")
+                            .createAt(LocalDate.now()).build());
                     System.out.println("회원가입 성공!");
                 }
                 catch (Exception e) {


### PR DESCRIPTION
## 개요
사용자가 회원가입한 날짜를 테이블에 저장합니다.
사용자가 회원가입한지 얼마나 지났는가를 나타내는 컬럼을 추가했습니다.

## 작업내용
- user 테이블에 DATE 타입의 create_at 컬럼을 추가했습니다.
- 사용자 회원가입 D+Day를 계산하는 API를 추가했습니다.

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/cc3efa65-1f56-48fe-97b7-a45609ef4b4c)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/86061ec4-bd0b-44c7-acf4-e4494091b9cf)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/7c18d6cb-2332-428e-8e24-c8c9276c047a)
