### PR TITLE
Add Password Validation To Register User

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/service/UserServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/UserServiceImpl.java
@@ -48,8 +48,9 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public ResponseEntity<? super RegisterResponse> register(RegisterRequest request) {
-        Pattern pattern = Pattern.compile("^[A-Za-z0-9]+$");
+        Pattern patternId = Pattern.compile("^[A-Za-z0-9]{4,}$");
         Pattern patternEmail = Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}(?:\\.[A-Za-z]{2,})?$");
+        Pattern patternPassword = Pattern.compile("^(?=.*[0-9])(?=.*[a-zA-Z])[0-9a-zA-Z!@#$%^&*()\\-_=+\\\\\\|{}\\[\\]:;\"'<>,.?/]{8,20}$");
         Gender g;
         String userId = request.getId();
         boolean isExistId = userRepo.existsById(userId);
@@ -58,7 +59,8 @@ public class UserServiceImpl implements UserService{
             return RegisterResponse.duplicateId();
         }
         else {
-            if (pattern.matcher(request.getId()).find() || patternEmail.matcher(request.getId()).find()) {
+            if ((patternId.matcher(request.getId()).find() || patternEmail.matcher(request.getId()).find())
+                    && patternPassword.matcher(request.getPassword()).find()) {
 
                 double bmi = calcBMI(request.getWeight(), request.getHeight());
                 int bmiId = setBMIRangeId(bmi);


### PR DESCRIPTION
## 개요
사용자 개인정보의 보안을 위해 비밀번호에 대한 유효성 검증을 추가합니다.

## 작업내용
사용자의 비밀번호는 다음과 같은 조건을 만족해야 합니다.
- 영어 대, 소문자를 구분합니다.
- 숫자를 포함
- 8자리 이상, 20자 이하
- 특수문자는 선택적으로 채택
이에 따른 유효성 검사를 실시하고, 만족하지 못할 시에는 회원가입이 불가능합니다.

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/a32899a5-9d9f-4837-bd6d-520acbf83226)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/3ece1856-a122-43db-a858-ed0b550d09f6)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/d56ec29f-dc11-4378-a4fb-d28e8e131bf1)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/589b1116-54e3-4f9c-b3b1-d22529a40127)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/6eaa0af2-8f98-4b6d-a7e7-db3ea6c8b792)

