### PR TITLE
Update API To Increment Routine Perform Counts

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/IncrementRoutinePerformRequest.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/IncrementRoutinePerformRequest.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class IncrementRoutinePerformRequest {
     private int uid;
     private int rid;
+    private int counts;
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/RoutineServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/RoutineServiceImpl.java
@@ -46,12 +46,15 @@ public class RoutineServiceImpl implements RoutineService {
             Optional<Routine> r = routineRepo.findById(request.getRid());
             if(r.isPresent()) {
                 Routine routine = r.get();
-                int performCountNow = routine.getPerformCounts();
-                if (performCountNow == routine.getMaxPerform()) {
+                if (request.getCounts() > routine.getMaxPerform()) {
+                    System.out.println("Count를 잘못 입력함");
+                    return 600;
+                }
+                if (routine.getPerformCounts() == routine.getMaxPerform()) {
                     System.out.println("이미 완료한 루틴입니다.");
                     return 300;
                 }
-                routine.setPerformCounts(performCountNow + 1);
+                routine.setPerformCounts(request.getCounts());
                 routineRepo.save(routine);
 
                 System.out.println("루틴 1회 성공 !");


### PR DESCRIPTION
## 개요
루틴 성공 횟수를 증가시키는 API에 성공 횟수를 Body에 담도록 수정했습니다.

## 작업 내용
Request 객체에 Counts 변수를 추가해 횟수 정보를 보내면 데이터베이스 routine 테이블을 수정합니다.

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/7c02f4df-75c9-408b-a261-be224df8243e)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/b4b5b57c-98db-451d-bbff-0f5b5f0f4f7e)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/14c45e21-fd70-404f-80f9-f4d417556e35)
