### PR TITLE
Add API To Delete User

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/UserController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/UserController.java
@@ -46,4 +46,9 @@ public class UserController {
     public CountingDaysResponse countingDays(Principal p) {
         return userService.countingDays(p.getName());
     }
+
+    @DeleteMapping()
+    public boolean deleteUser(Principal p) {
+        return userService.deleteUser(p.getName());
+    }
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/UserService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/UserService.java
@@ -16,4 +16,5 @@ public interface UserService {
     int modifyUser(ModifyUserRequest request);
     UserInfoResponse getUser(String id);
     CountingDaysResponse countingDays(String userId);
+    boolean deleteUser(String userId);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/UserServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/UserServiceImpl.java
@@ -206,6 +206,18 @@ public class UserServiceImpl implements UserService{
         return null;
     }
 
+    @Override
+    public boolean deleteUser(String userId) {
+        Optional<User> user = userRepo.findById(userId);
+        if (user.isEmpty()) return false;
+        try {
+            userRepo.deleteById(user.get().getUid());
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     private int setBMIRangeId(double bmi){
         int bmiId = 0;
         List<BMIRange> ranges = bmiRangeRepo.findAll();


### PR DESCRIPTION
## 개요
회원 탈퇴 API를 추가했습니다.

## 작업 내용
회원 탈퇴 API를 만들고 관련 DB 테이블을 모두 삭제하도록 사용자 아이디를 외래키로 사용하고 있는 테이블의 무결성 제약조건을 CASCADE로 변경했습니다.

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/90b94215-c871-4271-a53f-8208aa605cd6)
