### PR TITLE
Update API To Register Dosage With MedicineId

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/DosageRegisterRequest.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/DosageRegisterRequest.java
@@ -13,5 +13,4 @@ import java.time.LocalDate;
 public class DosageRegisterRequest {
     private String userId;
     private int medicineId;
-    private LocalDate startDate;
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/util/Times.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/util/Times.java
@@ -11,10 +11,13 @@ import java.util.List;
 @AllArgsConstructor
 public enum Times {
     BEFORE_BREAKFAST("아침 식전"),
+    DURING_BREAKFAST("아침 식중"),
     AFTER_BREAKFAST("아침 식후"),
     BEFORE_LUNCH("점심 식전"),
+    DURING_LUNCH("점심 식중"),
     AFTER_LUNCH("점심 식후"),
     BEFORE_DINNER("저녁 식전"),
+    DURING_DINNER("저녁 식중"),
     AFTER_DINNER("저녁 식후"),
     BEFORE_SLEEP("자기 전"),
     EMPTY_STOMACH("공복"),


### PR DESCRIPTION
## 개요
시나리오 변경으로 약품 복용 일정 등록 API를 수정했습니다.

## 작업 내용
- 복용 시작 일자를 더 이상 Request Body에 삽입하지 않습니다.
- 복용 일정을 등록하고자 하는 약품의 아이디 값만 가지고 등록합니다.

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/aac1e207-c562-428d-9e05-f9939f78d0d6)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/5de053e9-e60b-4554-bbd5-70dd7f8c674f)
