### PR TITLE
Add API To Modify Prescription And Delete Prescription

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/PrescriptionController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/PrescriptionController.java
@@ -3,6 +3,7 @@ package tech.bread.solt.doctornyangserver.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import tech.bread.solt.doctornyangserver.model.dto.request.PostPrescriptionRequest;
+import tech.bread.solt.doctornyangserver.model.dto.request.UpdatePrescriptionRequest;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionsResponse;
 import tech.bread.solt.doctornyangserver.service.PrescriptionService;
@@ -33,6 +34,11 @@ public class PrescriptionController {
     @GetMapping("/prescriptions")
     public List<GetPrescriptionsResponse> getPrescriptionsResponse(Principal p) {
         return prescriptionService.getPrescriptions(p.getName());
+    }
+
+    @PutMapping("/prescription")
+    public int update(@RequestBody UpdatePrescriptionRequest request) {
+        return prescriptionService.update(request);
     }
 
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/PrescriptionController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/PrescriptionController.java
@@ -41,4 +41,9 @@ public class PrescriptionController {
         return prescriptionService.update(request);
     }
 
+    @DeleteMapping("/prescription/{prescriptionId}")
+    public boolean delete(@PathVariable("prescriptionId") int prescriptionId) {
+        return prescriptionService.delete(prescriptionId);
+    }
+
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/UpdatePrescriptionRequest.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/UpdatePrescriptionRequest.java
@@ -1,0 +1,15 @@
+package tech.bread.solt.doctornyangserver.model.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdatePrescriptionRequest {
+    int prescriptionId;
+    String name;
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionService.java
@@ -15,4 +15,5 @@ public interface PrescriptionService {
     GetPrescriptionResponse getPrescription(int prescriptionId, String id);
 
     int update(UpdatePrescriptionRequest request);
+    boolean delete(int prescriptionId);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionService.java
@@ -1,6 +1,7 @@
 package tech.bread.solt.doctornyangserver.service;
 
 import tech.bread.solt.doctornyangserver.model.dto.request.PostPrescriptionRequest;
+import tech.bread.solt.doctornyangserver.model.dto.request.UpdatePrescriptionRequest;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionsResponse;
 
@@ -12,4 +13,6 @@ public interface PrescriptionService {
     List<GetPrescriptionsResponse> getPrescriptions(String id);
 
     GetPrescriptionResponse getPrescription(int prescriptionId, String id);
+
+    int update(UpdatePrescriptionRequest request);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionServiceImpl.java
@@ -1,8 +1,10 @@
 package tech.bread.solt.doctornyangserver.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import tech.bread.solt.doctornyangserver.model.dto.request.PostPrescriptionRequest;
+import tech.bread.solt.doctornyangserver.model.dto.request.UpdatePrescriptionRequest;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionsResponse;
 import tech.bread.solt.doctornyangserver.model.entity.Dosage;
@@ -20,6 +22,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PrescriptionServiceImpl implements PrescriptionService {
     private final UserRepo userRepo;
     private final PrescriptionRepo prescriptionRepo;
@@ -122,5 +125,22 @@ public class PrescriptionServiceImpl implements PrescriptionService {
         }
 
         return response;
+    }
+
+    @Override
+    public int update(UpdatePrescriptionRequest request) {
+        Optional<Prescription> optionalPrescription =
+                prescriptionRepo.getPrescriptionById(request.getPrescriptionId());
+
+        if (optionalPrescription.isPresent()) {
+            Prescription updatedPrescription = optionalPrescription.get();
+
+            updatedPrescription.setName(request.getName());
+            prescriptionRepo.save(updatedPrescription);
+            log.info("처방전 수정 성공");
+            return 200;
+        }
+        log.warn("처방전 정보를 찾지 못함");
+        return 100;
     }
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionServiceImpl.java
@@ -143,4 +143,16 @@ public class PrescriptionServiceImpl implements PrescriptionService {
         log.warn("처방전 정보를 찾지 못함");
         return 100;
     }
+
+    @Override
+    public boolean delete(int prescriptionId) {
+        Optional<Prescription> optionalPrescription = prescriptionRepo.getPrescriptionById(prescriptionId);
+
+        if (optionalPrescription.isPresent()) {
+            prescriptionRepo.delete(optionalPrescription.get());
+            log.info("처방전 정보 삭제 성공");
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## 개요
처방전 삭제 API와 수정 API를 추가했습니다.
처방전 수정 시에는 이름만 수정이 가능합니다.

## 작업 내용
- 처방전 ID 값을 사용해 처방전을 삭제하는 API를 추가했습니다. 해당 ID 값을 외래키로 갖고 있는 medicine과 dosage 데이터도 삭제합니다.
- 처방전 수정 시 이름만 수정이 가능합니다.

## 이미지
1. 처방전 수정
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/827d5950-61ee-4d6f-a589-4b6e6a3af1ed)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/a45bfeb6-be03-449a-9a0b-df60da4ec97e)

2. 처방전 삭제
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/d7a214cb-73e1-49f2-8c3f-f09fa7b40dac)
