### PR TITLE
Extend Expiration Time To Authenticate Token

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/security/JwtProvider.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/security/JwtProvider.java
@@ -20,7 +20,7 @@ public class JwtProvider {
     private String secretKey;
 
     public String create(String userId) {
-        Date expireDate = Date.from(Instant.now().plus(1, ChronoUnit.HOURS));
+        Date expireDate = Date.from(Instant.now().plus(24, ChronoUnit.HOURS));
         Key key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
 
         String jwt = Jwts.builder()


### PR DESCRIPTION
## 개요
토큰 유효시간을 1시간에서 24시간으로 늘렸습니다.

## 작업 내용
JWTProvider 클래스에서 JWT를 생성할 때 유효시간 값을 24시간으로 연장했습니다.