### PR TITLE
Add per serving amount when registering or modifying a meal plan

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/DietController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/DietController.java
@@ -57,8 +57,8 @@ public class DietController {
         return dietService.addIngestion(request, p.getName());
     }
 
-    @PostMapping("/ingestion/update")
-    public int updateIngestion(@RequestBody UpdateIngestionRequest request) {
+    @PutMapping("/ingestion")
+    public int updateIngestion(@RequestBody UpdateIngestionRequest request, Principal p) {
         return dietService.updateIngestion(request);
     }
 

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/AddIngestionRequest.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/AddIngestionRequest.java
@@ -12,9 +12,11 @@ import java.time.LocalDate;
 @Data
 @Builder
 public class AddIngestionRequest {
+    private LocalDate date;
     private int times;
     private String foodName;
     private double servingSize;
+    private double totalIngestionSize;
     private double calories;
     private double carbohydrate;
     private double protein;
@@ -24,5 +26,4 @@ public class AddIngestionRequest {
     private double cholesterol;
     private double saturatedFattyAcid;
     private double transFattyAcid;
-    private LocalDate date;
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/UpdateIngestionRequest.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/request/UpdateIngestionRequest.java
@@ -5,13 +5,18 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class UpdateIngestionRequest {
     int ingestionId;
+    private LocalDate date;
+    private int times;
     double servingSize;
+    double totalIngestionSize;
     double calories;
     double carbohydrate;
     double protein;

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/GetDietResponse.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/GetDietResponse.java
@@ -18,6 +18,7 @@ public class GetDietResponse {
     Times times;
     String name;
     Double servingSize;
+    Double totalIngestionSize;
     Double calories;
     Double carbohydrate;
     Double protein;

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/GetDietResponse.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/GetDietResponse.java
@@ -13,7 +13,7 @@ import tech.bread.solt.doctornyangserver.util.Times;
 @Builder
 public class GetDietResponse {
 
-    int dietId;
+    int ingestionId;
     int foodId;
     Times times;
     String name;

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/entity/FoodInformation.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/entity/FoodInformation.java
@@ -23,6 +23,9 @@ public class FoodInformation {
     @Column(name="serving_size")
     Double servingSize;
 
+    @Column(name="total_ingestion_size")
+    Double totalIngestionSize;
+
     @Column(name = "calories")
     Double calories;
 

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/DietServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/DietServiceImpl.java
@@ -180,6 +180,7 @@ public class DietServiceImpl implements DietService {
                                 .times(ingestion.getTimes())
                                 .name(f.getName())
                                 .servingSize(f.getServingSize())
+                                .totalIngestionSize(f.getTotalIngestionSize())
                                 .calories(f.getCalories())
                                 .carbohydrate(f.getCarbohydrate())
                                 .protein(f.getProtein())

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/DietServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/DietServiceImpl.java
@@ -118,6 +118,7 @@ public class DietServiceImpl implements DietService {
             FoodInformation foodInformation = FoodInformation.builder()
                     .name(request.getFoodName())
                     .servingSize(request.getServingSize())
+                    .totalIngestionSize(request.getTotalIngestionSize())
                     .calories(request.getCalories())
                     .carbohydrate(request.getCarbohydrate())
                     .protein(request.getProtein())
@@ -174,7 +175,7 @@ public class DietServiceImpl implements DietService {
                 FoodInformation f = ingestion.getFoodId();
 
                 result.add(GetDietResponse.builder()
-                                .dietId(ingestion.getId())
+                                .ingestionId(ingestion.getId())
                                 .foodId(ingestion.getFoodId().getFoodId())
                                 .times(ingestion.getTimes())
                                 .name(f.getName())
@@ -256,26 +257,33 @@ public class DietServiceImpl implements DietService {
 
     @Override
     public int updateIngestion(UpdateIngestionRequest request) {
-        Optional<Ingestion> ingestionOptional = ingestionRepo.findById(request.getIngestionId());
+        Optional<Ingestion> optionalIngestion = ingestionRepo.findById(request.getIngestionId());
 
-        if (ingestionOptional.isPresent()){
-            Optional<FoodInformation> foodOptional
-                    = foodInformationRepo.findById(ingestionOptional.get().getFoodId().getFoodId());
+        if (optionalIngestion.isPresent()){
+            Ingestion ingestion = optionalIngestion.get();
+            ingestion.setDate(request.getDate());
+            ingestion.setTimes(Times.ofOrdinal(Times.values().length-4+request.getTimes()));
+            ingestionRepo.save(ingestion);
+            System.out.println("섭취 날짜, 시간대 수정 완료");
 
-            if (foodOptional.isPresent()){
-                FoodInformation info = foodOptional.get();
-                info.setServingSize(request.getServingSize());
-                info.setCalories(request.getCalories());
-                info.setProtein(request.getProtein());
-                info.setFat(request.getFat());
-                info.setCarbohydrate(request.getCarbohydrate());
-                info.setSugars(request.getSugars());
-                info.setSalt(request.getSalt());
-                info.setCholesterol(request.getCholesterol());
-                info.setSaturatedFattyAcid(request.getSaturatedFattyAcid());
-                info.setTransFattyAcid(request.getTransFattyAcid());
-                foodInformationRepo.save(info);
-                
+            Optional<FoodInformation> optionalFood = foodInformationRepo.findById(ingestion.getFoodId().getFoodId());
+
+            if (optionalFood.isPresent()){
+                FoodInformation food = optionalFood.get();
+                food.setServingSize(request.getServingSize());
+                food.setTotalIngestionSize(request.getTotalIngestionSize());
+                food.setCalories(request.getCalories());
+                food.setProtein(request.getProtein());
+                food.setFat(request.getFat());
+                food.setCarbohydrate(request.getCarbohydrate());
+                food.setSugars(request.getSugars());
+                food.setSalt(request.getSalt());
+                food.setCholesterol(request.getCholesterol());
+                food.setSaturatedFattyAcid(request.getSaturatedFattyAcid());
+                food.setTransFattyAcid(request.getTransFattyAcid());
+                foodInformationRepo.save(food);
+                System.out.println("섭취 정보 수정 완료");
+
                 return 200;
             }
             System.out.println("찾는 음식에 대한 정보가 없음");


### PR DESCRIPTION
## 개요
식단 수정 시 1회 제공량 기반 계산을 위해 식단 등록, 수정 요청 항목에 1회 제공량 항목을 추가했습니다.

## 작업 내용

### 추가된 사항
식단 조회, 등록, 수정 API에 1회 제공량 파라미터를 추가했습니다.

### 변경 사항
섭취량을 나타내던 servingSize를 1회 제공량으로 수정했습니다.
이에 따라 섭취량은 totalIngestionSize 파라미터로 추가했습니다.

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/49b79bf5-40a4-4cab-a54c-d603af9d1b0c)
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/96e40d82-dca6-4b87-9756-f71db8ef9d52)
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/c3ebaffc-eafd-49e0-bc08-40c5e425ffbc)
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/6c7ff7bd-3253-4c80-84ab-aaee87b507f2)
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/cea52f40-4093-4435-a3b5-75472d072398)
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/24631019-24eb-419a-9e7a-b50759063ba5)
