### PR TITLE
Changed sorting when looking up prescriptions, added 3 search APIs in descending order before a specific date

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/PrescriptionController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/PrescriptionController.java
@@ -5,10 +5,13 @@ import org.springframework.web.bind.annotation.*;
 import tech.bread.solt.doctornyangserver.model.dto.request.PostPrescriptionRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.UpdatePrescriptionRequest;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionResponse;
+import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionsByDateResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionsResponse;
 import tech.bread.solt.doctornyangserver.service.PrescriptionService;
 
 import java.security.Principal;
+import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 
 @RestController
@@ -21,19 +24,24 @@ public class PrescriptionController {
         this.prescriptionService = prescriptionService;
     }
 
+    @GetMapping("/prescriptions")
+    public List<GetPrescriptionsResponse> getPrescriptions(Principal p) {
+        return prescriptionService.getPrescriptions(p.getName());
+    }
+
     @GetMapping("/prescriptions/{pid}")
-    public GetPrescriptionResponse getPrescriptionResponse(@PathVariable("pid") int pid, Principal p) {
+    public GetPrescriptionResponse getPrescription(@PathVariable("pid") int pid, Principal p) {
         return prescriptionService.getPrescription(pid, p.getName());
+    }
+
+    @GetMapping("/prescriptions/date/{date}")
+    public List<GetPrescriptionsByDateResponse> getPrescriptionsByDate(@PathVariable("date") LocalDate date, Principal p) {
+        return prescriptionService.getPrescriptionsByDate(date, p.getName());
     }
 
     @PostMapping("/prescriptions")
     public int addPrescription(@RequestBody PostPrescriptionRequest request, Principal p) {
         return prescriptionService.addPrescription(request, p.getName());
-    }
-
-    @GetMapping("/prescriptions")
-    public List<GetPrescriptionsResponse> getPrescriptionsResponse(Principal p) {
-        return prescriptionService.getPrescriptions(p.getName());
     }
 
     @PutMapping("/prescription")

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/GetPrescriptionsByDateResponse.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/GetPrescriptionsByDateResponse.java
@@ -1,0 +1,15 @@
+package tech.bread.solt.doctornyangserver.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetPrescriptionsByDateResponse {
+    private String name;
+    private LocalDate date;
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/repository/PrescriptionRepo.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/repository/PrescriptionRepo.java
@@ -4,11 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import tech.bread.solt.doctornyangserver.model.entity.Prescription;
 import tech.bread.solt.doctornyangserver.model.entity.User;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface PrescriptionRepo extends JpaRepository<Prescription, Integer> {
-    List<Prescription> getPrescriptionsByUserUid(User userUid);
-
-    Optional<Prescription> getPrescriptionById(int prescriptionId);
+    List<Prescription> findAllByUserUidOrderByDateDescIdDesc(User userUid);
+    List<Prescription> findTop3ByUserUidAndDateLessThanEqualOrderByDateDescIdDesc(User userUid, LocalDate date);
+    Optional<Prescription> findAllById(int prescriptionId);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/DosageServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/DosageServiceImpl.java
@@ -18,7 +18,6 @@ import tech.bread.solt.doctornyangserver.repository.UserRepo;
 import tech.bread.solt.doctornyangserver.util.Times;
 import tech.bread.solt.doctornyangserver.util.TimesConverter;
 
-import java.sql.Time;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,7 +75,7 @@ public class DosageServiceImpl implements DosageService {
             }
 
             LocalDate startDate = prescriptionRepo
-                    .getPrescriptionById(medicine.getPrescriptionId().getId())
+                    .findAllById(medicine.getPrescriptionId().getId())
                     .get().getDate();
 
             for (int i = 0; i < doseDays; i++) {

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/MedicineServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/MedicineServiceImpl.java
@@ -2,7 +2,6 @@ package tech.bread.solt.doctornyangserver.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -91,7 +90,7 @@ public class MedicineServiceImpl implements MedicineService {
     @Override
     public int register(RegisterMedicineRequest request, String id) {
         Optional<User> optionalUser = userRepo.findById(id);
-        Optional<Prescription> optionalPrescription = prescriptionRepo.getPrescriptionById(request.getPrescriptionId());
+        Optional<Prescription> optionalPrescription = prescriptionRepo.findAllById(request.getPrescriptionId());
         String[] dosageText = {"식전", "식중", "식후", "상관 없음"};
 
         if (optionalUser.isPresent()) {

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/PrescriptionService.java
@@ -3,8 +3,11 @@ package tech.bread.solt.doctornyangserver.service;
 import tech.bread.solt.doctornyangserver.model.dto.request.PostPrescriptionRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.UpdatePrescriptionRequest;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionResponse;
+import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionsByDateResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.GetPrescriptionsResponse;
 
+import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 
 public interface PrescriptionService {
@@ -16,4 +19,6 @@ public interface PrescriptionService {
 
     int update(UpdatePrescriptionRequest request);
     boolean delete(int prescriptionId);
+
+    List<GetPrescriptionsByDateResponse> getPrescriptionsByDate(LocalDate date, String id);
 }


### PR DESCRIPTION
## 개요
홈 화면과 처방전 화면 정렬을 동일하게 유지하기 위해 처방전 정렬을 수정했습니다. (내림차순)
홈 화면에서 특정 날짜 이전 처방전 3개 출력을 위해 API를 추가했습니다.

## 작업 내용

### 추가된 사항
특정 날짜로 처방전 목록 조회 시 해당 날짜로부터 내림차순 3개만 조회하는 API 추가

### 변경 사항
처방전 목록 조회 시 오름차순 -> 내림차순

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/b131195d-a309-4899-a6c4-e1e077668973)
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/ecc44809-878a-4824-8880-d831afd17adc)
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/62c577ea-6dfd-4904-a58d-0292b1351c19)
