### PR TITLE
Added 3 routine query APIs

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/RoutineController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/RoutineController.java
@@ -3,6 +3,7 @@ package tech.bread.solt.doctornyangserver.controller;
 import org.springframework.web.bind.annotation.*;
 import tech.bread.solt.doctornyangserver.model.dto.request.RegisterRoutineRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.UpdateRoutineRequest;
+import tech.bread.solt.doctornyangserver.model.dto.response.GetRoutineTop3ByDateResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.ShowRoutineResponse;
 import tech.bread.solt.doctornyangserver.service.RoutineService;
 
@@ -39,6 +40,11 @@ public class RoutineController {
     @GetMapping("/{date}")
     public List<ShowRoutineResponse> showRoutinePast(@PathVariable("date") LocalDate date, Principal principal) {
         return routineService.show(date, principal.getName());
+    }
+
+    @GetMapping("/date/{date}")
+    public List<GetRoutineTop3ByDateResponse> getRoutineTop3ByDate(@PathVariable("date") LocalDate date, Principal principal) {
+        return routineService.getRoutineTop3ByDate(date, principal.getName());
     }
 
     @DeleteMapping("/{routineId}")

--- a/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/GetRoutineTop3ByDateResponse.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/model/dto/response/GetRoutineTop3ByDateResponse.java
@@ -1,0 +1,18 @@
+package tech.bread.solt.doctornyangserver.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GetRoutineTop3ByDateResponse {
+    int id;
+    String name;
+    int max;
+    String color;
+    int counts;
+}

--- a/src/main/java/tech/bread/solt/doctornyangserver/repository/RoutineRepo.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/repository/RoutineRepo.java
@@ -19,4 +19,6 @@ public interface RoutineRepo extends JpaRepository<Routine, Integer> {
 
     boolean existsByUserUidAndRoutineNameAndTerm(User uid, String userName, int term);
     List<Routine> findByUserUidAndStartDateBetween(User uid, LocalDate startDate, LocalDate endDate);
+
+    List<Routine> findTop3ByUserUidAndStartDateBetweenOrderByStartDateAscRoutineIdAsc(User userUid, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/RoutineService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/RoutineService.java
@@ -2,6 +2,7 @@ package tech.bread.solt.doctornyangserver.service;
 
 import tech.bread.solt.doctornyangserver.model.dto.request.RegisterRoutineRequest;
 import tech.bread.solt.doctornyangserver.model.dto.request.UpdateRoutineRequest;
+import tech.bread.solt.doctornyangserver.model.dto.response.GetRoutineTop3ByDateResponse;
 import tech.bread.solt.doctornyangserver.model.dto.response.ShowRoutineResponse;
 
 import java.time.LocalDate;
@@ -15,4 +16,6 @@ public interface RoutineService {
     List<ShowRoutineResponse> show(LocalDate date, String id);
 
     boolean delete(int routineId);
+
+    List<GetRoutineTop3ByDateResponse> getRoutineTop3ByDate(LocalDate date, String id);
 }


### PR DESCRIPTION
## 개요
홈 화면에서 루틴 미리보기를 위해 특정 기간에 루틴 3개만 조회하는 API를 추가했습니다.

## 작업 내용

### 추가된 사항
특정 날짜가 포함된 기간에 등록 날짜, 루틴 아이디 오름차순으로 3개까지 조회하는 API를 추가했습니다.

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/83108398/e5374505-ebe7-4f80-9701-f7502050f984)
