### PR TITLE
Add feeding initialization API

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/NabiController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/NabiController.java
@@ -39,4 +39,9 @@ public class NabiController {
     public int feed(Principal p) {
         return nabiService.feed(p.getName());
     }
+
+    @GetMapping("/feed/reset")
+    public String resetFeed() {
+        return nabiService.resetFeed();
+    }
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/NabiService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/NabiService.java
@@ -13,4 +13,6 @@ public interface NabiService {
     List<GetChatResponse> getChats(String id, int page);
 
     int feed(String id);
+
+    String resetFeed();
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/NabiServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/NabiServiceImpl.java
@@ -146,6 +146,21 @@ public class NabiServiceImpl implements NabiService {
         return result;
     }
 
+    @Override
+    public String resetFeed() {
+        List<User> fedUsers = userRepo.findByFedIsTrue();
+        List<User> users = new ArrayList<>();
+
+        for (User user : fedUsers) {
+            user.setFed(false);
+            users.add(user);
+        }
+
+        userRepo.saveAll(users);
+        System.out.println("먹이 주기 초기화 완료");
+        return "먹이 주기 초기화 완료";
+    }
+
 
     private static String removeLastSentence(String text) {
         int lastPeriodIndex = text.lastIndexOf(".");


### PR DESCRIPTION
## 개요
시연을 위한 먹이주기 초기화 API 를 추가했습니다.

## 작업 내용

### 추가된 사항
모든 먹이주기 현황을 초기화하는 API 를 추가했습니다.

## 이슈
시연을 위한 API 이므로, 시연 이후에 삭제 예정입니다.

## 이미지
<img width="1332" alt="image" src="https://github.com/salt-bread-tech/nabi-server/assets/83108398/9de8d46c-a1d5-4dba-a849-7e1c2ae3543a">
