### PR TITLE
Add API To Delete Dosage By Medicine

### DIFF
--- a/src/main/java/tech/bread/solt/doctornyangserver/controller/DosageController.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/controller/DosageController.java
@@ -53,4 +53,10 @@ public class DosageController {
         request.setUserId(principal.getName());
         return dosageService.customize(request);
     }
+
+
+    @DeleteMapping("/medicine/{medicineId}")
+    public boolean deleteByMedicineId(@PathVariable("medicineId") int medicineId) {
+        return dosageService.deleteByMedicineId(medicineId);
+    }
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/DosageService.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/DosageService.java
@@ -15,4 +15,6 @@ public interface DosageService {
     boolean delete(int dosageId);
     int update(UpdateDosageRequest request);
     int customize(RegisterCustomDosageRequest request);
+
+    boolean deleteByMedicineId(int medicineId);
 }

--- a/src/main/java/tech/bread/solt/doctornyangserver/service/DosageServiceImpl.java
+++ b/src/main/java/tech/bread/solt/doctornyangserver/service/DosageServiceImpl.java
@@ -204,4 +204,22 @@ public class DosageServiceImpl implements DosageService {
         log.warn("등록 되지 않은 의약품");
         return 100;
     }
+
+    @Override
+    public boolean deleteByMedicineId(int medicineId) {
+        Optional<Medicine> optionalMedicine = medicineRepo.findById(medicineId);
+        if (optionalMedicine.isPresent()) {
+            List<Dosage> dosages = dosageRepo.findByMedicineId(optionalMedicine.get());
+
+            if (dosages.isEmpty()) {
+                log.warn("등록된 복용 일정이 없습니다.");
+                return false;
+            }
+            dosageRepo.deleteAll(dosages);
+            log.info("복용 일정 삭제 성공");
+            return true;
+        }
+        log.warn("해당 의약품이 존재하지 않음");
+        return false;
+    }
 }


### PR DESCRIPTION
## 개요
의약품 아이디 값으로 복용 일정을 일괄 삭제하는 API를 추가했습니다.

## 작업 내용
의약품 아이디를 외래키로 가지고 있는 행들을 가져오고, 해당 행들을 전부 삭제합니다.

## 이미지
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/2c514e29-6f1b-41c0-9107-5407c36d5c98)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/531ee4a0-32e5-4368-a8a8-61d0de4b7896)
![image](https://github.com/salt-bread-tech/nabi-server/assets/94215392/525816b2-83cb-47b7-aa20-64e0e16bc1a4)
